### PR TITLE
Fix pathfinding with negative X

### DIFF
--- a/incremental/Cavernous/queues.js
+++ b/incremental/Cavernous/queues.js
@@ -167,7 +167,7 @@ class ActionQueue extends Array {
 		
 		if (isNaN(+actionID) // not queue reference
 		    && !"UDLRI<=".includes(actionID) // not non-rune action
-		    && (!"NSP".includes(actionID[0]) || isNaN(+actionID[1]))) // not rune action or pathfinding
+		    && (!"NSP".includes(actionID[0]) || (isNaN(+actionID[1]) && isNaN(actionID.toString().substring(1,3))))) // not rune action or pathfinding
 		{
 			return;
 		}


### PR DESCRIPTION
Correctly checks for negative X coordinate when determining if an action might be pathfinding