### PR TITLE
Fix increase-at updating on CR completions

### DIFF
--- a/incremental/CavernousII/messages.js
+++ b/incremental/CavernousII/messages.js
@@ -158,7 +158,7 @@ let messages = [
 					Mining mana there will increase the conversion rate between gold and mana.`),
 	new Message("Compounding Realm", `
 					In the Compounding Realm, you feel like you're moving through molasses.
-					Each time you move, subsequent actions will take 2.5% longer.
+					Each time you move, subsequent actions will take 1% longer.
 					However, mining mana there will increase your ability to learn past 100.`),
 	new Message("Upgraded Duplication Rune", `
 					You've upgraded the Duplication rune!

--- a/incremental/CavernousII/realms.js
+++ b/incremental/CavernousII/realms.js
@@ -73,7 +73,7 @@ function getVerdantMultDesc(){
 }
 
 function getCompoundingMultDesc(){
-	return `Stat slowdown start: ${writeNumber(99 + getRealmMult("Compounding Realm", true), 4)}`;
+	return `Stat slowdown start: ${writeNumber(100 + getRealmMult("Compounding Realm", true), 4)}`;
 }
 
 const verdantMapping = {
@@ -129,7 +129,7 @@ let realms = [
 	// Clones cannot help each other at all.
 	new Realm(
 		"Compounding Realm",
-		"A realm where things get harder the more you do.  Each movement action completed (including walking - and pathfinding doesn't save you on that) increases the amount of time each subsequent task will take by 2.5%.  You'll get better at learning from repeated tasks (stat slowdown will start 0.05 points later per mana rock completion).",
+		"A realm where things get harder the more you do.  Each movement action completed (including walking - and pathfinding doesn't save you on that) increases the amount of time each subsequent task will take by 2.5%.  You'll get better at learning from repeated tasks (stat slowdown will start 0.01 points later per mana rock completion).",
 		() => Infinity,
 		() => {},
 		getCompoundingMultDesc,


### PR DESCRIPTION
This should cause the increase-at in tooltips to update immediately upon CR completions.

Also includes a small (100->99) increase-at calculation fix.