### PR TITLE
Fix increase-at updating on CR completions and slight miscalculation.

### DIFF
--- a/incremental/CavernousII/stats.js
+++ b/incremental/CavernousII/stats.js
@@ -52,7 +52,7 @@ class Stat {
 		this.dirty = true;
 	}
 
-	update() {
+	update(forceIncreaseAtUpdate = false) {
 		if (!this.dirty) return;
 		this.updateValue();
 		if (!this.node){
@@ -68,10 +68,10 @@ class Stat {
 		} else {
 			this.effectNode.innerText = `${writeNumber(this.current < 100 ? this.current + this.bonus : this.current * (1 + (this.bonus / 100)), 2)} (${writeNumber(this.base, 2)})`;
 			let increaseRequired;
-			let scalingStart = 100 + getRealmMult("Compounding Realm");
+			let scalingStart = 99 + getRealmMult("Compounding Realm");
 			if (this.base < scalingStart){
 				increaseRequired = (this.base + 1) ** (10/9) - 1;
-			} else if (this.lastIncreaseRequired && this.base - 0.01 < this.lastIncreaseUpdate){
+			} else if (!forceIncreaseAtUpdate && this.lastIncreaseRequired && this.base - 0.01 < this.lastIncreaseUpdate){
 				increaseRequired = this.lastIncreaseRequired;
 			} else {
 				let v = this.base, step = this.base;

--- a/incremental/CavernousII/zones.js
+++ b/incremental/CavernousII/zones.js
@@ -88,6 +88,10 @@ class Zone {
 		}
 		if (realms[currentRealm].name == "Compounding Realm" && this.index == 0 && getRealm("Compounding Realm").mult !== null){
 			getRealm("Compounding Realm").mult += 0.05;
+			stats.filter(s => s.learnable && s.base >= 99 + getRealmMult("Compounding Realm")).forEach(s => {
+				s.dirty = true;
+				s.update(true);
+			});		
 		}
 		this.display();
 	}


### PR DESCRIPTION
This should cause the increase-at in tooltips to update immediately upon CR completions.

Also includes a small (100->99) increase-at calculation fix.

This time with 67% less trash commits!